### PR TITLE
Use t shorcut in org-export-dispatcher

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -108,7 +108,7 @@
   :export-block "HTML"
   :filters-alist '((:filter-final-output . org-twbs-final-function))
   :menu-entry
-  '(?h "Export to TWBS HTML"
+  '(?t "Export to TWBS HTML"
        ((?H "As HTML buffer" org-twbs-export-as-html)
         (?h "As HTML file" org-twbs-export-to-html)
         (?o "As HTML file and open"


### PR DESCRIPTION
Use `t` shorcut in org-export-dispatcher in place of `h` witch is already used by the html exporter. 
Now it's possible to export to HTML even when `ox-twbs` loaded.
