### PR TITLE
Change defgroup tag to not clobber ox-html

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -355,8 +355,8 @@ customize `org-twbs-head-include-default-style'.")
 ;;; User Configuration Variables
 
 (defgroup org-export-twbs nil
-  "Options for exporting Org mode files to HTML."
-  :tag "Org Export HTML"
+  "Options for exporting Org mode files to HTML compatible with Twitter's Bootstrap."
+  :tag "Org Export twbs"
   :group 'org-export)
 
 ;;;; Bold, etc.


### PR DESCRIPTION
As described in https://github.com/marsmining/ox-twbs/issues/3, the current defgroup :tag for ox-twbs is the same as ox-html. This could lead to confusion among users who use emac's customize-group settings. This commit changes the :tag and the docstribg to better differentiate it from ox-html in the customize-group menu.