### PR TITLE
Fix a couple html warnings on export

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -165,7 +165,7 @@
   "Regular expressions for special string conversion.")
 
 (defconst org-twbs-scripts
-  "<script type=\"text/javascript\">
+  "<script>
 $(function() {
     'use strict';
 
@@ -179,7 +179,7 @@ $(function() {
   "Basic JavaScript that is needed by HTML files produced by Org mode.")
 
 (defconst org-twbs-style-default
-  "<style type=\"text/css\">
+  "<style>
 /* org mode styles on top of twbs */
 
 html {
@@ -836,7 +836,7 @@ MathJax.Hub.Config({
   }
 });
 </script>
-<script type=\"text/javascript\" src=\"%PATH\"></script>"
+<script src=\"%PATH\"></script>"
   "The MathJax setup for HTML files."
   :group 'org-export-twbs
   :type 'string)


### PR DESCRIPTION
Exports seem to be causing a couple of warnings in html validators, for an example, see:

https://validator.w3.org/nu/?doc=http%3A%2F%2Fclubctrl.com%2Forg%2Fprog%2Fox-twbs.html.

This attempts to correct those warnings.