### PR TITLE
handle changes in org-link-escape between 9.1 and 9.3 fixes #52

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -8,7 +8,7 @@
 ;;         Brandon van Beekum <marsmining at gmail dot com>
 ;; URL: https://github.com/marsmining/ox-twbs
 ;; Keywords: org, html, publish, twitter, bootstrap
-;; Version: 1.1.1
+;; Version: 1.1.2
 
 ;; This file is not part of GNU Emacs.
 
@@ -2450,9 +2450,16 @@ INFO is a plist holding contextual information.  See
          (path
           (cond
            ((member type '("http" "https" "ftp" "mailto"))
-            (org-link-escape
-             (org-link-unescape
-              (concat type ":" raw-path)) '(32 91 93 37)))
+            (with-no-warnings
+              ;; handle changes in arity and naming between org 9.1 and 9.3
+              (condition-case nil
+                  (org-link-escape
+                   (org-link-unescape
+                    (concat type ":" raw-path)) '(32 91 93 37))
+                (error
+                 (org-link-encode
+                  (org-link-decode
+                   (concat type ":" raw-path)) '(32 91 93 37))))))
            ((string= type "file")
             ;; Treat links to ".org" files as ".html", if needed.
             (setq raw-path


### PR DESCRIPTION
First try using `org-link-encode` and if error use `org-link-escape`.