### PR TITLE
trim string for output of fixed-width blocks

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -1976,7 +1976,8 @@ CONTENTS is nil.  INFO is a plist holding contextual information."
   (format "<pre class=\"example\">\n%s</pre>"
           (org-twbs-do-format-code
            (org-remove-indentation
-            (org-element-property :value fixed-width)))))
+            (org-trim
+             (org-element-property :value fixed-width))))))
 
 ;;;; Footnote Reference
 


### PR DESCRIPTION
re: #61 

Was able to reproduce bug with `Emacs 27.0.50 (Org-mode 9.1.9)` but could not reproduce with latest org-mode from Melpa Stable `Emacs 27.0.50 (Org-mode 9.3.6)`. With the `org-trim` in this PR both versions worked correctly.