### PR TITLE
Update org-twbs for org 9.8 compatibility

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -8,6 +8,7 @@
 ;;         Brandon van Beekum <marsmining at gmail dot com>
 ;; URL: https://github.com/marsmining/ox-twbs
 ;; Keywords: org, html, publish, twitter, bootstrap
+;; Package-Requires: ((org "9.8"))
 ;; Version: 1.1.4
 
 ;; This file is not part of GNU Emacs.
@@ -2090,9 +2091,11 @@ holding contextual information."
              (and (org-export-last-sibling-p headline info)
                   (org-twbs-end-plain-list type))))
         ;; Standard headline.  Export it as a section.
-        (let ((extra-class (org-element-property :HTML_CONTAINER_CLASS headline))
-              (level1 (+ level (1- org-twbs-toplevel-hlevel)))
-              (first-content (car (org-element-contents headline))))
+        (let* ((extra-class (org-element-property :HTML_CONTAINER_CLASS headline))
+               (level1 (+ level (1- org-twbs-toplevel-hlevel)))
+               (first-content (car (org-element-contents headline)))
+               (has-section (and (consp first-content)
+                                 (eq (org-element-type first-content) 'section))))
           (format "<%s id=\"%s\" class=\"%s\">%s%s</%s>\n"
                   (org-twbs--container headline info)
                   (format "outline-container-%s"
@@ -2105,10 +2108,10 @@ holding contextual information."
                   ;; When there is no section, pretend there is an
                   ;; empty one to get the correct <div class="outline-
                   ;; ...> which is needed by `org-info.js'.
-                  (if (not (eq (org-element-type first-content) 'section))
-                      (concat (org-twbs-section first-content "" info)
-                              contents)
-                    contents)
+                  (if has-section
+                      contents
+                    (concat (org-twbs--outline-text headline info "")
+                            contents))
                   (org-twbs--container headline info)))))))
 
 (defun org-twbs--container (headline info)
@@ -2777,6 +2780,20 @@ CONTENTS is nil.  INFO is a plist holding contextual information."
 
 ;;;; Section
 
+(defun org-twbs--outline-text (headline info &optional contents)
+  "Return outline text container for HEADLINE.
+INFO is the export state plist.  CONTENTS is the string that should
+appear inside the container."
+  (let* ((class-num (+ (org-export-get-relative-level headline info)
+                       (1- org-twbs-toplevel-hlevel)))
+         (section-number
+          (mapconcat #'number-to-string
+                     (org-export-get-headline-number headline info) "-")))
+    (format "<div class=\"outline-text-%d\" id=\"text-%s\">\n%s</div>"
+            class-num
+            (or (org-element-property :CUSTOM_ID headline) section-number)
+            (or contents ""))))
+
 (defun org-twbs-section (section contents info)
   "Transcode a SECTION element from Org to HTML.
 CONTENTS holds the contents of the section.  INFO is a plist
@@ -2784,18 +2801,7 @@ holding contextual information."
   (let ((parent (org-export-get-parent-headline section)))
     ;; Before first headline: no container, just return CONTENTS.
     (if (not parent) contents
-      ;; Get div's class and id references.
-      (let* ((class-num (+ (org-export-get-relative-level parent info)
-                           (1- org-twbs-toplevel-hlevel)))
-             (section-number
-              (mapconcat
-               'number-to-string
-               (org-export-get-headline-number parent info) "-")))
-        ;; Build return value.
-        (format "<div class=\"outline-text-%d\" id=\"text-%s\">\n%s</div>"
-                class-num
-                (or (org-element-property :CUSTOM_ID parent) section-number)
-                (or contents ""))))))
+      (org-twbs--outline-text parent info contents))))
 
 ;;;; Radio Target
 

--- a/test/ox-twbs-test.el
+++ b/test/ox-twbs-test.el
@@ -1,0 +1,43 @@
+;;; ox-twbs-test.el --- Tests for ox-twbs -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'org)
+(require 'ox)
+(require 'ox-twbs)
+
+(defmacro org-twbs-test-with-export (input &rest body)
+  "Evaluate BODY with OUTPUT bound to the export of INPUT.
+INPUT is an Org string.  Within BODY the variable `output' is bound to
+HTML produced by `org-export-string-as' using the twbs back-end."
+  (declare (indent 1))
+  `(let ((org-export-show-temporary-export-buffer nil)
+         (org-export-use-babel nil)
+         (org-export-with-toc nil)
+         (org-html-html5-fancy nil))
+     (let ((output (org-export-string-as ,input 'twbs t)))
+       ,@body)))
+
+(ert-deftest org-twbs-export-includes-following-headlines ()
+  "Headlines after the first should appear in the exported HTML."
+  (org-twbs-test-with-export "* Parent\n** Child\n*** Grandchild\n"
+    (let ((headline-regexp
+           (lambda (id text)
+             (format
+              "<h[0-9]+ id=\\\"%s\\\">\\(?:<span[^>]*>[^<]*</span> \\)?%s</h[0-9]+>"
+              id text))))
+      (should (string-match-p (funcall headline-regexp "sec-1" "Parent") output))
+      (should (string-match-p (funcall headline-regexp "sec-1-1" "Child") output))
+      (should (string-match-p (funcall headline-regexp "sec-1-1-1" "Grandchild") output)))))
+
+(ert-deftest org-twbs-export-wraps-headlines-without-section ()
+  "Headlines that lack a section node still get outline containers."
+  (org-twbs-test-with-export "* Parent\n** Child\n*** Grandchild\n"
+    (let* ((text-pos (string-match "<div class=\\\"outline-text-[0-9]+\\\" id=\\\"text-1-1\\\">" output))
+           (grandchild-pos (string-match "<h[0-9]+ id=\\\"sec-1-1-1\\\">" output)))
+      (should text-pos)
+      (should grandchild-pos)
+      (should (< text-pos grandchild-pos)))))
+
+(provide 'ox-twbs-test)
+
+;;; ox-twbs-test.el ends here


### PR DESCRIPTION
Summary

Added a reusable helper to generate outline-text containers directly from headlines, avoiding dependence on implicit section nodes during export.

Updated headline rendering to detect missing section elements and wrap their contents with the new helper so later headings render correctly under Org 9.8.

Added org-twbs-test-with-export helper macro and two ERT regression tests that assert later headlines and their outline containers are emitted in the TWBS exporter output.

Relaxed the headline assertions in org-twbs-export-includes-following-headlines so they tolerate the section-number spans added by Org during export.